### PR TITLE
CachedBlockDevice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humantime"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +97,8 @@ name = "libfs"
 version = "0.1.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru 0.1.13 (git+https://github.com/Orycterope/lru-rs)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -106,6 +117,14 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lru"
+version = "0.1.13"
+source = "git+https://github.com/Orycterope/lru-rs#f6cfc8b5e3370aafbbb285f6f15d32c0e5c55c66"
+dependencies = [
+ "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -176,6 +195,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "spin"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "structview"
@@ -291,10 +320,12 @@ dependencies = [
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
+"checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum lru 0.1.13 (git+https://github.com/Orycterope/lru-rs)" = "<none>"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
@@ -305,6 +336,8 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53ee8cfdddb2e0291adfb9f13d31d3bbe0a03c9a402c01b1e24188d86c35b24f"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum structview 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ffab9ec4541b704fb27870c489e8aa9470932be1065a96f593f58dd94eaddcbb"
 "checksum structview_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eeeaae92ced781bd03eac99f7e5a17c6241c779a99d782377e118c033cd5fa97"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"

--- a/libfs/Cargo.toml
+++ b/libfs/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.0"
+lru = { git = "https://github.com/Orycterope/lru-rs" }
+spin = "0.5.0"

--- a/libfs/src/block.rs
+++ b/libfs/src/block.rs
@@ -1,3 +1,7 @@
+
+use lru::LruCache;
+use spin::Mutex;
+
 /// Represent a block operation error.
 #[derive(Debug)]
 pub enum BlockError {
@@ -21,7 +25,7 @@ pub struct Block {
     pub contents: [u8; Block::LEN],
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, PartialEq, Ord, Eq)]
 /// Represent the position of a block on a block device.
 pub struct BlockIndex(pub u32);
 
@@ -113,4 +117,156 @@ pub trait BlockDevice: Sized {
 
     /// Return the amount of blocks hold by the block device.
     fn count(&self) -> BlockResult<BlockCount>;
+}
+
+/// A BlockDevice that reduces device accesses by keeping the most recently used blocks in a cache.
+///
+/// It will keep track of which blocks are dirty, and will only write those ones to device when
+/// flushing, or when they are evicted from the cache.
+///
+/// When a CachedBlockDevice is dropped, it flushes its cache.
+pub struct CachedBlockDevice<B: BlockDevice> {
+    block_device: B,
+    lru_cache: Mutex<LruCache<BlockIndex, CachedBlock>>
+}
+
+struct CachedBlock {
+    /// Bool indicating whether this block should be written to device when flushing.
+    dirty: bool,
+    /// The data of this block.
+    data: Block,
+}
+
+impl<B: BlockDevice> CachedBlockDevice<B> {
+    /// Creates a new CachedBlockDevice that wraps `device`, and can hold at most `cap` blocks in cache.
+    pub fn new(device: B, cap: usize) -> CachedBlockDevice<B> {
+        CachedBlockDevice {
+            block_device: device,
+            lru_cache: Mutex::new(LruCache::new(cap))
+        }
+    }
+
+    /// Writes every dirty cached block to device.
+    ///
+    /// Note that this will not empty the cache, just perform device writes
+    /// and update dirty blocks as now non-dirty.
+    ///
+    /// This function has no effect on lru order.
+    pub fn flush(&self) -> BlockResult<()> {
+        for (index, block) in self.lru_cache.lock().iter_mut() {
+            if block.dirty {
+                self.block_device.raw_write(core::slice::from_ref(&block.data), *index)?;
+                block.dirty = false;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<B: BlockDevice> Drop for CachedBlockDevice<B> {
+    /// Dropping a CachedBlockDevice flushes it.
+    ///
+    /// If a device write fails, it is silently ignored.
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+impl<B: BlockDevice> BlockDevice for CachedBlockDevice<B> {
+    /// Attempts to fill `blocks` with blocks found in the cache, and will fetch them from device if it can't.
+    ///
+    /// Will update the access time of every block involved.
+    fn raw_read(&self, blocks: &mut [Block], index: BlockIndex) -> BlockResult<()> {
+        let mut lru = self.lru_cache.lock();
+        // check if we can satisfy the request only from what we have in cache
+        let mut fully_cached = true;
+        if blocks.len() > lru.len() {
+            // requested more blocks that cache is holding
+            fully_cached = false
+        } else {
+            // check each block is found in the cache
+            for i in 0..blocks.len() {
+                if !lru.contains(&BlockIndex(index.0 + i as u32)) {
+                    fully_cached = false;
+                    break
+                }
+            }
+        }
+
+        if !fully_cached {
+            // we must read from device
+            self.block_device.raw_read(blocks, index)?
+        }
+
+        // update from/to cache
+        for (i, block) in blocks.iter_mut().enumerate() {
+            if let Some(cached_block) = lru.get(&BlockIndex(index.0 + i as u32)) {
+                // block was found in cache, its access time was updated.
+                if fully_cached || cached_block.dirty {
+                    // fully_cached: block[i] is uninitialized, copy it from cache.
+                    // dirty:        block[i] is initialized from device if !fully_cached,
+                    //               but we hold a newer dirty version in cache, overlay it.
+                    *block = cached_block.data.clone();
+                }
+            } else {
+                // add the block we just read to the cache.
+                // if cache is full, flush its lru entry
+                if lru.len() == lru.cap() {
+                    let (evicted_index, evicted_block) = lru.pop_lru().unwrap();
+                    if evicted_block.dirty {
+                        self.block_device.raw_write(core::slice::from_ref(&evicted_block.data), evicted_index)?;
+                    }
+                }
+                let new_cached_block = CachedBlock { dirty: false, data: block.clone() };
+                lru.put(BlockIndex(index.0 + i as u32), new_cached_block);
+            }
+        }
+        Ok(())
+    }
+
+    /// Adds dirty blocks to the cache.
+    ///
+    /// If the block was already present in the cache, it will simply be updated.
+    ///
+    /// When the cache is full, least recently used blocks will be evicted and written to device.
+    /// This operation may fail, and this function will return an error when it happens.
+    fn raw_write(&self, blocks: &[Block], index: BlockIndex) -> BlockResult<()> {
+        let mut lru = self.lru_cache.lock();
+
+        if blocks.len() < lru.cap() {
+            for (i, block) in blocks.iter().enumerate() {
+                let new_block = CachedBlock { dirty: true, data: block.clone() };
+                // add it to the cache
+                // if cache is full, flush its lru entry
+                if lru.len() == lru.cap() {
+                    let (evicted_index, evicted_block) = lru.pop_lru().unwrap();
+                    if evicted_block.dirty {
+                        self.block_device.raw_write(core::slice::from_ref(&evicted_block.data), evicted_index)?;
+                    }
+                }
+                lru.put(BlockIndex(index.0 + i as u32), new_block);
+            }
+        } else {
+            // we're performing a big write, that will evict all cache blocks.
+            // evict it in one go, and repopulate with the first `cap` blocks from `blocks`.
+            for (evicted_index, evicted_block) in lru.iter() {
+                if evicted_block.dirty
+                    // if evicted block is `blocks`, don't bother writing it as we're about to re-write it anyway.
+                    && !(index >= *evicted_index && index < BlockIndex(evicted_index.0 + blocks.len() as u32)) {
+                    self.block_device.raw_write(core::slice::from_ref(&evicted_block.data), *evicted_index)?;
+                }
+            }
+            // write in one go
+            self.block_device.raw_write(blocks, index)?;
+            // add first `cap` blocks to cache
+            for (i, block) in blocks.iter().take(lru.cap()).enumerate() {
+                lru.put(BlockIndex(index.0 + i as u32), CachedBlock { dirty: false, data: block.clone() })
+            }
+        }
+        Ok(())
+    }
+
+    fn count(&self) -> BlockResult<BlockCount> {
+        self.block_device.count()
+    }
 }


### PR DESCRIPTION
A BlockDevice that reduces device accesses by keeping the most recently used blocks in a cache.

It will keep track of which blocks are dirty, and will only write those ones to device when
flushing, or when they are evicted from the cache.